### PR TITLE
 CVE-2018-1336 - Improve handing of overflow in the UTF-8 decoder with supplementary c…

### DIFF
--- a/java/org/apache/tomcat/util/buf/Utf8Decoder.java
+++ b/java/org/apache/tomcat/util/buf/Utf8Decoder.java
@@ -278,6 +278,11 @@ public class Utf8Decoder extends CharsetDecoder {
                 outRemaining--;
             } else {
                 if (outRemaining < 2) {
+                    // Encoded with 4 bytes. inIndex currently points
+                    // to the final byte. Move it back to first byte.
+                    inIndex -= 3;
+                    in.position(inIndex - in.arrayOffset());
+                    out.position(outIndex - out.arrayOffset());
                     return CoderResult.OVERFLOW;
                 }
                 cArr[outIndex++] = (char) ((jchar >> 0xA) + 0xD7C0);

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -84,6 +84,10 @@
         align it with the default cookie parser. Document the impact system properties have on
         cookie name validation. (mark)
       </fix>
+      <fix>
+        Improve handing of overflow in the UTF-8 decoder with supplementary
+        characters. (markt)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Coyote">


### PR DESCRIPTION
…haracters.

git-svn-id: https://svn.apache.org/repos/asf/tomcat/tc8.5.x/trunk@1830374 13f79535-47bb-0310-9956-ffa450edef68