### PR TITLE
Provide a mechanism that enables the container to check if a componen…

### DIFF
--- a/java/org/apache/catalina/loader/WebappClassLoaderBase.java
+++ b/java/org/apache/catalina/loader/WebappClassLoaderBase.java
@@ -75,6 +75,7 @@ import org.apache.tomcat.util.ExceptionUtils;
 import org.apache.tomcat.util.IntrospectionUtils;
 import org.apache.tomcat.util.compat.JreCompat;
 import org.apache.tomcat.util.res.StringManager;
+import org.apache.tomcat.util.security.PermissionCheck;
 
 /**
  * Specialized web application class loader.
@@ -120,7 +121,7 @@ import org.apache.tomcat.util.res.StringManager;
  * @author Craig R. McClanahan
  */
 public abstract class WebappClassLoaderBase extends URLClassLoader
-        implements Lifecycle, InstrumentableClassLoader, WebappProperties {
+        implements Lifecycle, InstrumentableClassLoader, WebappProperties, PermissionCheck {
 
     private static final Log log = LogFactory.getLog(WebappClassLoaderBase.class);
 
@@ -1333,6 +1334,24 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
         }
         return (pc);
 
+    }
+
+
+    @Override
+    public boolean check(Permission permission) {
+        if (!Globals.IS_SECURITY_ENABLED) {
+            return true;
+        }
+        Policy currentPolicy = Policy.getPolicy();
+        if (currentPolicy != null) {
+            URL contextRootUrl = resources.getResource("/").getCodeBase();
+            CodeSource cs = new CodeSource(contextRootUrl, (Certificate[]) null);
+            PermissionCollection pc = currentPolicy.getPermissions(cs);
+            if (pc.implies(permission)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 

--- a/java/org/apache/tomcat/util/digester/Digester.java
+++ b/java/org/apache/tomcat/util/digester/Digester.java
@@ -23,11 +23,13 @@ import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.Permission;
 import java.util.EmptyStackException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.PropertyPermission;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -37,6 +39,7 @@ import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.apache.tomcat.util.ExceptionUtils;
 import org.apache.tomcat.util.IntrospectionUtils;
+import org.apache.tomcat.util.security.PermissionCheck;
 import org.xml.sax.Attributes;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.ErrorHandler;
@@ -78,6 +81,13 @@ public class Digester extends DefaultHandler2 {
         implements IntrospectionUtils.PropertySource {
         @Override
         public String getProperty( String key ) {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            if (cl instanceof PermissionCheck) {
+                Permission p = new PropertyPermission(key, "read");
+                if (!((PermissionCheck) cl).check(p)) {
+                    return null;
+                }
+            }
             return System.getProperty(key);
         }
     }

--- a/java/org/apache/tomcat/util/security/PermissionCheck.java
+++ b/java/org/apache/tomcat/util/security/PermissionCheck.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomcat.util.security;
+
+import java.security.Permission;
+
+/**
+ * This interface is implemented by components to enable privileged code to
+ * check whether the component has a given permission.
+ * This is typically used when a privileged component (e.g. the container) is
+ * performing an action on behalf of an untrusted component (e.g. a web
+ * application) without the current thread having passed through a code source
+ * provided by the untrusted component. Because the current thread has not
+ * passed through a code source provided by the untrusted component the
+ * SecurityManager assumes the code is trusted so the standard checking
+ * mechanisms can't be used.
+ */
+public interface PermissionCheck {
+
+    /**
+     * Does this component have the given permission?
+     *
+     * @param permission The permission to test
+     *
+     * @return {@code false} if a SecurityManager is enabled and the component
+     *         does not have the given permission, otherwise {@code false}
+     */
+    boolean check(Permission permission);
+}


### PR DESCRIPTION
…t (typically a web application) has been granted a given permission when running under a SecurityManager without the current execution stack having to have passed through the component. Use this new mechanism to extend SecurityManager protection to the system property replacement feature of the digester.

git-svn-id: https://svn.apache.org/repos/asf/tomcat/tc8.5.x/trunk@1754726 13f79535-47bb-0310-9956-ffa450edef68